### PR TITLE
options: drop unsupported DaemonTimeout from FreeBSD fuse

### DIFF
--- a/options.go
+++ b/options.go
@@ -153,7 +153,7 @@ func ExclCreate() MountOption {
 // DaemonTimeout sets the time in seconds between a request and a reply before
 // the FUSE mount is declared dead.
 //
-// OS X and FreeBSD only. Others ignore this option.
+// OS X only. Others ignore this option.
 func DaemonTimeout(name string) MountOption {
 	return daemonTimeout(name)
 }

--- a/options_freebsd.go
+++ b/options_freebsd.go
@@ -13,10 +13,7 @@ func volumeName(name string) MountOption {
 }
 
 func daemonTimeout(name string) MountOption {
-	return func(conf *mountConfig) error {
-		conf.options["timeout"] = name
-		return nil
-	}
+	return dummyOption
 }
 
 func noAppleXattr(conf *mountConfig) error {


### PR DESCRIPTION
See https://man.freebsd.org/mount_fusefs for details, there is no `-o timeout=...` available.

```
This is SeaweedFS version 30GB 2.19  freebsd amd64
mount point owner uid=0 gid=0 mode=drwxr-xr-x
current uid=269 gid=269
I0127 19:54:31 88686 leveldb_store.go:40] filer store dir: /var/cache/seaweedfs/ac1a/meta
I0127 19:54:31 88686 file_util.go:23] Folder /var/cache/seaweedfs/ac1a/meta Permission: -rwxr-xr-x
2021/01/27 19:54:31 mount helper error: mount_fusefs: -o timeout=: option not supported
I0127 19:54:31 88686 mount_std.go:196] mount: mount_fusefs: exit status 1
```